### PR TITLE
Make parser more resilient to corrupt files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ include = ["/src", "!/src/test-data"]
 
 [dependencies]
 num-traits = "0.2"
-nom = { version = "6", features = ["alloc"] }
+nom = { version = "7", features = ["alloc"] }
 itertools = "0.10"
 integer-encoding = "3"
 chrono = "0.4"
@@ -19,6 +19,6 @@ thiserror = "1"
 
 [dev-dependencies]
 anyhow = "1"
-insta = { version = "1.12", features = ["glob"] }
+insta = { version = "1.18", features = ["glob"] }
 serde = { version = "1", features = ["derive"] }
-serde-big-array = { version = "0.3", features = ["const-generics"] }
+serde-big-array = { version = "0.4", features = ["const-generics"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ thiserror = "1"
 
 [dev-dependencies]
 anyhow = "1"
-insta = { version = "1.18", features = ["glob"] }
+insta = { version = "1.19", features = ["glob", "yaml"] }
 serde = { version = "1", features = ["derive"] }
-serde-big-array = { version = "0.4", features = ["const-generics"] }
+serde-big-array = "0.4"

--- a/src/frame/data.rs
+++ b/src/frame/data.rs
@@ -36,7 +36,7 @@ fn parse_owned_frame_payload<'a: 'f, 'f, 'i: 'a>(
         let mut input = input;
         let mut ret = Vec::with_capacity(field_encodings.len());
 
-        for encoding in field_encodings.iter().copied() {
+        for encoding in field_encodings {
             let (remaining_input, value) = encoding.parse(input)?;
             input = remaining_input;
             match value {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub enum BlackboxRecord<'a> {
     Garbage(usize),
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum Strictness {
     Strict,
     Lenient,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,16 +109,18 @@ impl<'a> BlackboxReader<'a> {
         loop {
             match parse_next_frame(&self.header, self.remaining_bytes) {
                 Ok((remaining_bytes, frame)) => {
-                    match remaining_bytes.first() {
-                        Some(b'I') | Some(b'P') | Some(b'S') | Some(b'G') | Some(b'H') | Some(b'E') | None => {
-                            // Next frame looks valid or it's an EOF
-                        }
-                        _ => {
-                            // Skip the parsed frame
-                            // Continue from the second byte of the parsed frame, because if it's invalid,
-                            // we can't be sure what size it was and where next frame starts
-                            self.remaining_bytes = &self.remaining_bytes[1..];
-                            continue;
+                    if self.strictness == Strictness::Lenient {
+                        match remaining_bytes.first() {
+                            Some(b'I') | Some(b'P') | Some(b'S') | Some(b'G') | Some(b'H') | Some(b'E') | None => {
+                                // Next frame looks valid or it's an EOF
+                            }
+                            _ => {
+                                // Skip the parsed frame
+                                // Continue from the second byte of the parsed frame, because if it's invalid,
+                                // we can't be sure what size it was and where next frame starts
+                                self.remaining_bytes = &self.remaining_bytes[1..];
+                                continue;
+                            }
                         }
                     }
                     self.remaining_bytes = remaining_bytes;

--- a/src/stream/header.rs
+++ b/src/stream/header.rs
@@ -406,7 +406,7 @@ impl<I> From<nom::error::Error<I>> for ParseHeadersError<I> {
 pub fn parse_headers(input: &[u8]) -> IResult<&[u8], Header, ParseHeadersError<&[u8]>> {
     let (input, header) = fold_many0(
         parse_header,
-        HeaderBuilder::default(),
+        HeaderBuilder::default,
         |mut header, header_frame| {
             match header_frame {
                 Frame::Product(product) => header.product = Some(product.to_owned()),


### PR DESCRIPTION
I have some files which are mostly fine, but have a block of corrupted bytes. Before this PR, the parser would stop, but official [blackblox-log-viewer](https://github.com/betaflight/blackbox-log-viewer/blob/master/js/flightlog_parser.js#L1728) tries to continue searching for the next frame and eventually continues. 
This PR makes it do the same.

Also fixed a clippy warning as a drive-by

[corrupt_logs.zip](https://github.com/ilya-epifanov/fc-blackbox/files/9199024/corrupt_logs.zip)

