### PR TITLE
Fix logs with timestamp > i32::MAX

### DIFF
--- a/src/stream/predictor.rs
+++ b/src/stream/predictor.rs
@@ -244,7 +244,7 @@ pub(crate) struct AddConstantPredictor {
 
 impl IPredictor for AddConstantPredictor {
     fn predict(&self, value: i64, snapshot: &mut Snapshot<'_>) {
-        snapshot.current[self.field_ix] = (self.base + value) as i32 as i64;
+        snapshot.current[self.field_ix] = (self.base + value) as i64;
     }
 }
 


### PR DESCRIPTION
This log stops parsing after loopIteration 2034484, which has timestamp of 2147482635 and the next frame (not parsed) has timestamp of 2147492773, which is above i32 range, but still within u32 range. 

I'm not sure why this cast was there, but removing it fixes parsing this log

[LOG00002.zip](https://github.com/user-attachments/files/16119968/LOG00002.zip)
